### PR TITLE
Update module version to 2026.2.1

### DIFF
--- a/PowerShellProtect.psd1
+++ b/PowerShellProtect.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'PowerShellProtect.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2022.11.0'
+    ModuleVersion     = '2026.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
## Summary
- Update the PowerShellProtect module version from 2022.11.0 to 2026.2.1

## Testing
- Not run (not requested)