### PR TITLE
Expose built-in rule metadata through configuration

### DIFF
--- a/Engine.Tests/Analyze/BuiltInConditionCatalogTests.cs
+++ b/Engine.Tests/Analyze/BuiltInConditionCatalogTests.cs
@@ -1,0 +1,19 @@
+using Engine;
+using System.Linq;
+using Xunit;
+
+namespace Engine.Tests.Analyze
+{
+    public class BuiltInConditionCatalogTests
+    {
+        [Fact]
+        public void ShouldEnumerateAllBuiltInRules()
+        {
+            var rules = BuiltInConditionCatalog.GetRules().ToList();
+
+            Assert.Equal(12, rules.Count);
+            Assert.Contains(rules, rule => rule.Name == "amsiBypass");
+            Assert.All(rules, rule => Assert.False(string.IsNullOrWhiteSpace(rule.Description)));
+        }
+    }
+}

--- a/PowerShellProtect/Analyze/Analyzer.cs
+++ b/PowerShellProtect/Analyze/Analyzer.cs
@@ -50,21 +50,7 @@ namespace Engine
                 new ScriptStringCondition(),
             }.ToDictionary(m => m.Name.ToLower(), m => m);
 
-            _builtInConditions = new List<ICondition>
-            {
-                new AmsiBypass(),
-                new LoggingBypass(),
-                new DisableDefender(),
-                new PowerSploit(),
-                new AssemblyLoad(),
-                new ReflectionEmit(),
-                new MarshalClass(),
-                new PersistentWmi(),
-                new BloudHound(),
-                new Kerberoasting(),
-                new InvokeExpression(),
-                new Log4J()
-            };
+            _builtInConditions = BuiltInConditionCatalog.Create().ToList();
 
             foreach (var builtInCondition in _builtInConditions)
             {

--- a/PowerShellProtect/Analyze/BuiltInConditionCatalog.cs
+++ b/PowerShellProtect/Analyze/BuiltInConditionCatalog.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using Engine.Configuration;
+using PowerShellProtect.Analyze.Conditions;
+
+namespace Engine
+{
+    internal static class BuiltInConditionCatalog
+    {
+        internal static IEnumerable<ICondition> Create()
+        {
+            return new ICondition[]
+            {
+                new AmsiBypass(),
+                new LoggingBypass(),
+                new DisableDefender(),
+                new PowerSploit(),
+                new AssemblyLoad(),
+                new ReflectionEmit(),
+                new MarshalClass(),
+                new PersistentWmi(),
+                new BloudHound(),
+                new Kerberoasting(),
+                new InvokeExpression(),
+                new Log4J()
+            };
+        }
+
+        internal static IEnumerable<BuiltInRule> GetRules()
+        {
+            return Create().Select(condition => new BuiltInRule
+            {
+                Name = condition.Name,
+                Description = condition.Description
+            });
+        }
+    }
+}

--- a/PowerShellProtect/Cmdlets/GetConfigurationCommand.cs
+++ b/PowerShellProtect/Cmdlets/GetConfigurationCommand.cs
@@ -1,5 +1,7 @@
-﻿using Engine.Configuration;
+﻿using Engine;
+using Engine.Configuration;
 using System.Management.Automation;
+using System.Linq;
 
 namespace PowerShellProtect.Cmdlets
 {
@@ -9,8 +11,11 @@ namespace PowerShellProtect.Cmdlets
         protected override void BeginProcessing()
         {
             var config = new Config();
+            var configuration = config.GetConfiguration();
 
-            WriteObject(config.GetConfiguration());
+            configuration.BuiltInRules = BuiltInConditionCatalog.GetRules().ToList();
+
+            WriteObject(configuration);
         }
     }
 }

--- a/PowerShellProtect/Configuration/Configuration.cs
+++ b/PowerShellProtect/Configuration/Configuration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Serialization;
 
 namespace Engine.Configuration
 {
@@ -9,6 +10,15 @@ namespace Engine.Configuration
         public List<Action> Actions { get; set; } = new List<Action>();
         public BuiltIn BuiltIn { get; set; } = new BuiltIn();
         public AiConfiguration AI { get; set; } = new AiConfiguration();
+
+        [XmlIgnore]
+        public List<BuiltInRule> BuiltInRules { get; set; } = new List<BuiltInRule>();
+    }
+
+    public class BuiltInRule
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
     }
 
     public class AiConfiguration

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Install-Module PowerShellProtect
 Install-PowerShellProtect
 ```
 
+## Inspect built-in rules
+
+`Get-PSPConfiguration` includes the built-in rules that ship with the module. The
+`BuiltInRules` property lists each rule's name and description; it is informational
+only and is not written into exported configuration XML.
+
+```powershell
+(Get-PSPConfiguration).BuiltInRules | Format-Table Name, Description -Wrap
+```
+
 ## Resources
 
 - [License](./LICENSE)


### PR DESCRIPTION
## Summary
- Centralize built-in condition creation in a reusable catalog
- Expose built-in rule names and descriptions through `Get-PSPConfiguration`
- Keep rule metadata informational and excluded from exported XML
- Document built-in rule inspection and add catalog coverage tests

## Testing
- Added an xUnit unit test verifying all 12 built-in rules and their descriptions

Fixes: https://github.com/ironmansoftware/powershell-protect/issues/1