### PR TITLE
Add language mode conditions for Constrained Language enforcement

### DIFF
--- a/Engine.Tests/Analyze/Conditions/LanguageModeTests.cs
+++ b/Engine.Tests/Analyze/Conditions/LanguageModeTests.cs
@@ -1,0 +1,38 @@
+using Engine.Analyze.Conditions;
+using Xunit;
+
+namespace Engine.Tests.Analyze.Conditions
+{
+    public class LanguageModeTests
+    {
+        [Fact]
+        public void ShouldMatchConstrainedLanguageMode()
+        {
+            var condition = new LanguageModeCondition();
+
+            var result = condition.Analyze(new ScriptContext { LanguageMode = "ConstrainedLanguage" }, new Configuration.Condition
+            {
+                Property = "languagemode",
+                Operator = "equals",
+                Value = "ConstrainedLanguage"
+            });
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldMatchAFullLanguageViolation()
+        {
+            var condition = new LanguageModeCondition();
+
+            var result = condition.Analyze(new ScriptContext { LanguageMode = "FullLanguage" }, new Configuration.Condition
+            {
+                Property = "languagemode",
+                Operator = "notequals",
+                Value = "ConstrainedLanguage"
+            });
+
+            Assert.True(result);
+        }
+    }
+}

--- a/PowerShellProtect/Analyze/Analyzer.cs
+++ b/PowerShellProtect/Analyze/Analyzer.cs
@@ -42,6 +42,7 @@ namespace Engine
                 new DomainControllerCondition(),
                 new ComputerNameCondition(),
                 new DomainCondition(),
+                new LanguageModeCondition(),
                 new CommandCondition(),
                 new ScriptCondition(),
                 new ContentPathCondition(),

--- a/PowerShellProtect/Analyze/Conditions/LanguageMode.cs
+++ b/PowerShellProtect/Analyze/Conditions/LanguageMode.cs
@@ -1,0 +1,17 @@
+namespace Engine.Analyze.Conditions
+{
+    /// <summary>
+    /// Matches the language mode of the PowerShell runspace that AMSI is scanning.
+    /// </summary>
+    internal class LanguageModeCondition : StringCondition
+    {
+        public override string Name => "languagemode";
+
+        public override string Description => "Matches the language mode of the PowerShell runspace that submitted the script.";
+
+        public override string GetValue(ScriptContext context)
+        {
+            return context.LanguageMode ?? string.Empty;
+        }
+    }
+}

--- a/PowerShellProtect/Cmdlets/NewConditionCommand.cs
+++ b/PowerShellProtect/Cmdlets/NewConditionCommand.cs
@@ -10,7 +10,7 @@ namespace PowerShellProtect.Cmdlets
     public class NewConditionCommand : PSCmdlet
     {
         [Parameter(Mandatory = true)]
-        [ValidateSet("admin", "domaincontroller", "computername", "domain", "ApplicationName", "command", "script", "contentpath", "variable", "member", "string", "applicationHash", "assembly", "assemblyHash")]
+        [ValidateSet("admin", "domaincontroller", "computername", "domain", "languagemode", "ApplicationName", "command", "script", "contentpath", "variable", "member", "string", "applicationHash", "assembly", "assemblyHash")]
         public string Property { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = "NotEquals")]

--- a/PowerShellProtect/ScriptContext.cs
+++ b/PowerShellProtect/ScriptContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation.Language;
+using System.Management.Automation.Runspaces;
 
 namespace Engine
 {
@@ -11,11 +12,17 @@ namespace Engine
         public string Script { get; set; }
         public string ContentName { get; set; }
         public string ApplicationName { get; set; }
+        /// <summary>
+        /// The language mode of the runspace that submitted the script to AMSI.
+        /// This is null when the script was not submitted from a PowerShell runspace.
+        /// </summary>
+        public string LanguageMode { get; set; }
         public Guid Id { get; set; } = Guid.NewGuid();
         public static ConcurrentDictionary<DateTime, ScriptContext> History { get; } = new ConcurrentDictionary<DateTime, ScriptContext>();
 
         public ScriptContext()
         {
+            LanguageMode = Runspace.DefaultRunspace?.SessionStateProxy?.LanguageMode.ToString();
             History.TryAdd(DateTime.Now, this);
         }
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Install-Module PowerShellProtect
 Install-PowerShellProtect
 ```
 
+## Enforce Constrained Language Mode
+
+Use a `languagemode` condition with a blocking action to prevent scripts from running unless the submitting PowerShell runspace is in Constrained Language Mode:
+
+```powershell
+$condition = New-PSPCondition -Property languagemode -NotEquals -Value ConstrainedLanguage
+$action = New-PSPAction -Block
+$rule = New-PSPRule -Name 'Require Constrained Language Mode' -Condition $condition -Action $action
+$configuration = New-PSPConfiguration -Rule $rule -Action $action
+```
+
+This rule observes the mode of the runspace that AMSI is currently scanning. It is a guardrail, not a replacement for enforcing Constrained Language Mode with WDAC, AppLocker, or a locked-down session configuration: code running with Full Language capabilities can attempt to disable AMSI or change its own session state before a later scan.
+
 ## Resources
 
 - [License](./LICENSE)


### PR DESCRIPTION
## Summary

- Capture the PowerShell runspace language mode in `ScriptContext`
- Add `languagemode` condition support and cmdlet validation
- Document a Constrained Language Mode blocking rule
- Add unit tests for language mode matching

## Testing

- Unit tests added for constrained and full language mode conditions